### PR TITLE
Update boundwize/structarmed to version 0.7.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.5",
+        "boundwize/structarmed": "^0.7.6",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae5a1423c2ba2b94d9f4d83519079260",
+    "content-hash": "cc995113119500e06c9ab867599f954f",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.5",
+            "version": "0.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "6d3e9b3890048fba0277e961f26f0bc08fe00d3f"
+                "reference": "27222c45da6e7c7a0eefac55c6e85359bdb29305"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/6d3e9b3890048fba0277e961f26f0bc08fe00d3f",
-                "reference": "6d3e9b3890048fba0277e961f26f0bc08fe00d3f",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/27222c45da6e7c7a0eefac55c6e85359bdb29305",
+                "reference": "27222c45da6e7c7a0eefac55c6e85359bdb29305",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.5"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.6"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-22T06:54:53+00:00"
+            "time": "2026-05-22T14:00:28+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -148,16 +148,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "c384125d81e7cee7c8abffe550d972343d377cb9"
+                "reference": "e63da1fe3301a2c50a3e5693fa7e0c9756cbac1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/c384125d81e7cee7c8abffe550d972343d377cb9",
-                "reference": "c384125d81e7cee7c8abffe550d972343d377cb9",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/e63da1fe3301a2c50a3e5693fa7e0c9756cbac1f",
+                "reference": "e63da1fe3301a2c50a3e5693fa7e0c9756cbac1f",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.5",
+                "boundwize/structarmed": "^0.7.6",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -268,7 +268,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-22T07:32:53+00:00"
+            "time": "2026-05-22T16:43:33+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.5` to `0.7.6`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`