### PR TITLE
Update boundwize/structarmed to version 0.7.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.10",
+        "boundwize/structarmed": "^0.7.11",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.1",
         "ghostwriter/testify": "^0.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9771497b4323a2aafdc9e8c65b19b66c",
+    "content-hash": "35c930ca0d358453200e28a73e97564a",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.10",
+            "version": "0.7.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "35c3929ce13f726ae5384773d7272fc402b0366d"
+                "reference": "b8ead2b5fd9a62f9c98bb6d92c440215ca512b47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/35c3929ce13f726ae5384773d7272fc402b0366d",
-                "reference": "35c3929ce13f726ae5384773d7272fc402b0366d",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/b8ead2b5fd9a62f9c98bb6d92c440215ca512b47",
+                "reference": "b8ead2b5fd9a62f9c98bb6d92c440215ca512b47",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.10"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.11"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-25T12:23:38+00:00"
+            "time": "2026-05-25T22:59:15+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.10` to `0.7.11`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`